### PR TITLE
Pthread make error

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@
 export
 
 CFLAGS = -Wall -Wextra -ggdb -std=gnu99
-LDFLAGS = -lz -lvorbisfile
+LDFLAGS = -lz -lvorbisfile -pthread
 
 LD = $(CC)
 


### PR DESCRIPTION
When I `make`ed the project, I got this error:

```
LD despotify
/usr/bin/ld: session.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[1]: *** [despotify] Fout 1
make: *** [clients/despotify] Fout 2
```

So I added `-pthread` to the build flags
